### PR TITLE
Add account system demos for remaining SOLID principles

### DIFF
--- a/DependencyInversionPrinciple/DependencyInversion.cpp
+++ b/DependencyInversionPrinciple/DependencyInversion.cpp
@@ -1,0 +1,50 @@
+#include <iostream>
+#include <string>
+#include <vector>
+
+// Abstraction for product storage
+class ProductRepository {
+public:
+    virtual ~ProductRepository() = default;
+    virtual std::vector<std::string> allProducts() const = 0;
+};
+
+// Low-level module using in-memory data
+class MemoryRepository : public ProductRepository {
+    std::vector<std::string> products{"Keyboard", "Mouse"};
+public:
+    std::vector<std::string> allProducts() const override {
+        return products;
+    }
+};
+
+// Another low-level module, e.g. a database
+class DatabaseRepository : public ProductRepository {
+public:
+    std::vector<std::string> allProducts() const override {
+        return {"DB Laptop", "DB Phone"};
+    }
+};
+
+// High-level module depends only on the abstraction
+class InventoryReport {
+    const ProductRepository& repo;
+public:
+    explicit InventoryReport(const ProductRepository& r) : repo(r) {}
+    void print() const {
+        for (const auto& name : repo.allProducts()) {
+            std::cout << name << '\n';
+        }
+    }
+};
+
+int main() {
+    MemoryRepository memRepo;
+    DatabaseRepository dbRepo;
+
+    InventoryReport r1(memRepo);
+    InventoryReport r2(dbRepo);
+
+    r1.print();
+    r2.print();
+}

--- a/DependencyInversionPrinciple/DependencyInversion.txt
+++ b/DependencyInversionPrinciple/DependencyInversion.txt
@@ -1,0 +1,3 @@
+The Dependency Inversion Principle (DIP) says high-level modules should depend on abstractions, not concrete details.
+
+This demo introduces a `ProductRepository` interface so that an `InventoryReport` can retrieve product names from either an in-memory list or a database class without modification.

--- a/InterfaceSegregationPrinciple/InterfaceSegregation.cpp
+++ b/InterfaceSegregationPrinciple/InterfaceSegregation.cpp
@@ -1,0 +1,63 @@
+#include <iostream>
+#include <map>
+#include <string>
+
+// Separate interfaces for reading and writing stock
+class InventoryReader {
+public:
+    virtual ~InventoryReader() = default;
+    virtual int getQuantity(const std::string& name) const = 0;
+};
+
+class InventoryWriter {
+public:
+    virtual ~InventoryWriter() = default;
+    virtual void setQuantity(const std::string& name, int qty) = 0;
+};
+
+// Concrete class implementing both interfaces
+class InventoryDB : public InventoryReader, public InventoryWriter {
+    std::map<std::string, int> stock;
+public:
+    int getQuantity(const std::string& name) const override {
+        auto it = stock.find(name);
+        return it == stock.end() ? 0 : it->second;
+    }
+    void setQuantity(const std::string& name, int qty) override {
+        stock[name] = qty;
+    }
+};
+
+// Client that only reads
+class StockReport {
+    const InventoryReader& reader;
+public:
+    explicit StockReport(const InventoryReader& r) : reader(r) {}
+    void print(const std::string& name) const {
+        std::cout << name << ": " << reader.getQuantity(name) << " units\n";
+    }
+};
+
+// Client that reads and writes
+class RestockService {
+    InventoryReader& reader;
+    InventoryWriter& writer;
+public:
+    RestockService(InventoryReader& r, InventoryWriter& w) : reader(r), writer(w) {}
+    void restock(const std::string& name, int qty) {
+        int current = reader.getQuantity(name);
+        writer.setQuantity(name, current + qty);
+    }
+};
+
+int main() {
+    InventoryDB db;
+    db.setQuantity("Keyboard", 5);
+
+    StockReport report(db);       // uses only reader
+    RestockService restock(db, db); // uses both reader and writer
+
+    report.print("Keyboard");
+    restock.restock("Keyboard", 10);
+    report.print("Keyboard");
+}

--- a/InterfaceSegregationPrinciple/InterfaceSegregation.txt
+++ b/InterfaceSegregationPrinciple/InterfaceSegregation.txt
@@ -1,0 +1,3 @@
+The Interface Segregation Principle (ISP) advises using multiple, specific interfaces rather than a single general-purpose one.
+
+Here we split inventory access into `InventoryReader` and `InventoryWriter`. Reporting tools depend only on the reader interface, while the restock service requires both, so each client uses only the methods it needs.

--- a/LiskovSubstitutionPrinciple/Liskov.cpp
+++ b/LiskovSubstitutionPrinciple/Liskov.cpp
@@ -1,0 +1,54 @@
+#include <iostream>
+#include <string>
+
+// Base interface for all products
+class Product {
+public:
+    virtual ~Product() = default;
+    virtual std::string name() const = 0;
+    virtual double price() const = 0;
+};
+
+// Extended interface for products that can be shipped
+class ShippableProduct : public Product {
+public:
+    virtual void ship() const = 0;
+};
+
+class Book : public ShippableProduct {
+    std::string title;
+    double unitPrice;
+public:
+    Book(std::string t, double p) : title(std::move(t)), unitPrice(p) {}
+    std::string name() const override { return title; }
+    double price() const override { return unitPrice; }
+    void ship() const override { std::cout << "Shipping book: " << title << '\n'; }
+};
+
+class OnlineCourse : public Product {
+    std::string courseName;
+    double rate;
+public:
+    OnlineCourse(std::string n, double r) : courseName(std::move(n)), rate(r) {}
+    std::string name() const override { return courseName; }
+    double price() const override { return rate; }
+};
+
+void printPrice(const Product& p) {
+    std::cout << p.name() << " costs $" << p.price() << '\n';
+}
+
+void deliver(const ShippableProduct& p) {
+    p.ship();
+}
+
+int main() {
+    Book book("C++ Primer", 45.0);
+    OnlineCourse course("SOLID Principles", 100.0);
+
+    printPrice(book);    // Works with any Product
+    printPrice(course);
+
+    deliver(book);       // Works with any ShippableProduct
+    // deliver(course);  // Compile-time error if uncommented
+}

--- a/LiskovSubstitutionPrinciple/LiskovSubstitution.txt
+++ b/LiskovSubstitutionPrinciple/LiskovSubstitution.txt
@@ -1,0 +1,3 @@
+The Liskov Substitution Principle (LSP) states that objects of a base type should be replaceable with objects of derived types without affecting program correctness.
+
+In this example we separate product shipping into a `ShippableProduct` interface. Physical items like books implement it, while digital products only satisfy the basic `Product` interface. Functions written against `Product` work with either kind without forcing digital items to implement meaningless shipping behaviour.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # SOLID Demo Project
 
-This repository contains a small C++ program demonstrating the five SOLID principles:
+This repository contains a small C++ program demonstrating the five SOLID principles.  
+The main example lives in the `Factorisation` directory and exercises all of the principles together.  
+Smaller demonstrations for each principle can be found in their own folders.
+
+The principles are:
 
 1. **Single Responsibility** – each class in the `Factorisation` directory handles one focused task. Examples include `Product`, `Customer`, `InventoryUI`, and `Transaction`.
 2. **Open/Closed** – behaviour is extended through abstractions without modifying existing classes. `ReceiptFormat` and the new `DiscountStrategy` hierarchy allow new receipt or discount types to be introduced with no changes to the consumers.
-3. **Liskov Substitution** – objects of `DiscountStrategy` or `ReceiptFormat` derived classes can replace their base classes without side effects.
-4. **Interface Segregation** – small interfaces such as `ReceiptFormat`, `PurchaseHistoryFormatter`, and `Report` expose only the operations a client needs.
-5. **Dependency Inversion** – high level modules depend on abstractions. `Transaction` uses the `ReceiptFormat` interface, while `ProductManager` stores `DiscountStrategy` objects.
+3. **Liskov Substitution** – physical and digital products share a base `Product` interface so either can be used where a product is expected.
+4. **Interface Segregation** – inventory access is split into reader and writer interfaces so clients depend only on what they use.
+5. **Dependency Inversion** – reports obtain products through a `ProductRepository` abstraction, decoupling them from concrete storage.
+
+Demo programs for these principles appear in the `LiskovSubstitutionPrinciple`, `InterfaceSegregationPrinciple` and `DependencyInversionPrinciple` folders using product and inventory examples.
 
 ## Building
 


### PR DESCRIPTION
## Summary
- update Liskov Substitution example to use products and shipping
- split inventory reading/writing to demonstrate Interface Segregation
- fetch products through repository abstraction for Dependency Inversion
- describe new demos in README

## Testing
- `g++ -std=c++17 LiskovSubstitutionPrinciple/Liskov.cpp -o /tmp/liskov_demo`
- `g++ -std=c++17 InterfaceSegregationPrinciple/InterfaceSegregation.cpp -o /tmp/isp_demo`
- `g++ -std=c++17 DependencyInversionPrinciple/DependencyInversion.cpp -o /tmp/dip_demo`
- `g++ -std=c++17 -Wall -Wextra Factorisation/*.cpp -o /tmp/main_demo`


------
https://chatgpt.com/codex/tasks/task_e_686f501524d48328b9ed89d9f02c8241